### PR TITLE
hotfix for metric label issue on oracle operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sims",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "sims",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "A super-simple fsp simulator",
   "main": "src/index.js",
   "author": "ModusBox",
   "contributors": [
     "Georgi Georgiev <georgi.georgiev@modusbox.com>",
     "Miguel de Barros <miguel.debarros@modusbox.com>",
-    "Murthy Kakarlamudi <murthy@modusbox.com>"
+    "Murthy Kakarlamudi <murthy@modusbox.com>",
+    "Rajiv Mothilal <rajiv.mothilal@modusbox.com>"
   ],
   "repository": {
     "type": "git",

--- a/src/oracle/handler.js
+++ b/src/oracle/handler.js
@@ -34,7 +34,7 @@ exports.createParticipantsByTypeAndId = function (request, h) {
   const histTimerEnd = Metrics.getHistogram(
     'sim_request',
     'Histogram for Simulator http operations',
-    ['success', 'operation', 'source', 'destination']
+    ['success', 'fsp', 'operation', 'source', 'destination']
   ).startTimer()
   Logger.debug(`createParticipantByTypeId::ID=${request.params.ID} payload=${request.payload}`)
   addNewRequest(request)
@@ -69,7 +69,7 @@ exports.getParticipantsByTypeId = function (request, h) {
   const histTimerEnd = Metrics.getHistogram(
     'sim_request',
     'Histogram for Simulator http operations',
-    ['success', 'operation', 'source', 'destination']
+    ['success', 'fsp', 'operation', 'source', 'destination']
   ).startTimer()
   Logger.debug(`getParticipantsByTypeId::ID=${request.params.ID}`)
   addNewRequest(request)
@@ -93,7 +93,7 @@ exports.updateParticipantsByTypeId = function (request, h) {
   const histTimerEnd = Metrics.getHistogram(
     'sim_request',
     'Histogram for Simulator http operations',
-    ['success', 'operation', 'source', 'destination']
+    ['success', 'fsp', 'operation', 'source', 'destination']
   ).startTimer()
   Logger.debug(`updateParticipantByTypeId::ID=${request.params.ID} payload=${request.payload}`)
   addNewRequest(request)
@@ -127,7 +127,7 @@ exports.delParticipantsByTypeId = function (request, h) {
   const histTimerEnd = Metrics.getHistogram(
     'sim_request',
     'Histogram for Simulator http operations',
-    ['success', 'operation', 'source', 'destination']
+    ['success', 'fsp', 'operation', 'source', 'destination']
   ).startTimer()
   Logger.debug(`delParticipantsByTypeId::ID=${request.params.ID}`)
   addNewRequest(request)
@@ -156,7 +156,7 @@ exports.createParticipantsBatch = function (request, h) {
   const histTimerEnd = Metrics.getHistogram(
     'sim_request',
     'Histogram for Simulator http operations',
-    ['success', 'operation', 'source', 'destination']
+    ['success', 'fsp', 'operation', 'source', 'destination']
   ).startTimer()
   let responseObject = {
     partyList: []
@@ -224,7 +224,7 @@ exports.getRequestByTypeId = function (request, h) {
   const histTimerEnd = Metrics.getHistogram(
     'sim_request',
     'Histogram for Simulator http operations',
-    ['success', 'operation', 'source', 'destination']
+    ['success', 'fsp', 'operation', 'source', 'destination']
   ).startTimer()
   const responseData = requestsCache.get(request.params.ID)
   requestsCache.del(request.params.ID)
@@ -236,7 +236,7 @@ exports.getRequestById = function (request, h) {
   const histTimerEnd = Metrics.getHistogram(
     'sim_request',
     'Histogram for Simulator http operations',
-    ['success', 'operation', 'source', 'destination']
+    ['success', 'fsp', 'operation', 'source', 'destination']
   ).startTimer()
   const responseData = batchRequestCache.get(request.params.requestId)
   requestsCache.del(request.params.requestId)


### PR DESCRIPTION
- Updated metric initialise for each of the Oracle operations to include the "fsp" label.

This resolves the following error -> `2019-05-22T08:49:10.137Z - error: Added label "fsp" is not included in initial labelset: [ 'success', 'operation', 'source', 'destination' ]`

Maintenance update:
- Added Rajiv to maintainer list