### PR TITLE
fix/817-broken-integration-tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,20 @@ FROM node:10.15.1-alpine
 
 WORKDIR /opt/simulators
 #COPY logs /opt/simulators/logs
-COPY src /opt/simulators/src
-COPY package.json /opt/simulators
 
 RUN apk --no-cache add --virtual native-deps \
-  g++ gcc libgcc libstdc++ linux-headers make python && \
-  npm install --quiet node-gyp -g &&\
-  npm install --quiet --production && \
-  apk del native-deps
+  g++ gcc libgcc libstdc++ linux-headers make python 
 
-EXPOSE 8444
+
+COPY package*.json /opt/simulators/
+
+RUN npm install --quiet node-gyp -g &&\
+  npm install --quiet --production
+
+RUN apk del native-deps
+
+COPY src /opt/simulators/src
+
 
 # Create empty log file
 #RUN touch ./logs/combined.log
@@ -19,4 +23,5 @@ EXPOSE 8444
 # Link the stdout to the application log file
 #RUN ln -sf /dev/stdout ./logs/combined.log
 
+EXPOSE 8444
 CMD ["node", "./src/index.js"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simulators that act as mock payer fsp and payee fsp which interact with the Swit
 | PARTIES_ENDPOINT | Mojaloop Callback Endpoint for Parties | 'http://localhost:1080' | |
 | QUOTES_ENDPOINT | Mojaloop Callback Endpoint for Quotes | 'http://localhost:1080' | |
 | TRANSFERS_ENDPOINT | Mojaloop Callback Endpoint for Transfers | 'http://localhost:1080' |
-| TRANSFERS_FULFIL_RESPONSE_DISABLED | Flag to disabled the Fulfil response callback to the TRANSFER_ENDPOINT | 'false' |
+| TRANSFERS_FULFIL_RESPONSE_DISABLED | Flag to disable the Fulfil response callback to the TRANSFER_ENDPOINT | 'false' |
 | TRANSFERS_FULFILMENT | ILP Fulfilment value | 'XoSz1cL0tljJSCp_VtIYmPNw-zFUgGfbUqf69AagUzY' |
 | TRANSFERS_CONDITION | ILP Fulfilment condition | 'HOr22-H3AfTDHrSkPjJtVPRdKouuMkDXTR4ejlQa8Ks' |
 | TRANSFERS_ILPPACKET | ILP Packet | 'AQAAAAAAAADIEHByaXZhdGUucGF5ZWVmc3CCAiB7InRyYW5zYWN0aW9uSWQiOiIyZGY3NzRlMi1mMWRiLTRmZjctYTQ5NS0yZGRkMzdhZjdjMmMiLCJxdW90ZUlkIjoiMDNhNjA1NTAtNmYyZi00NTU2LThlMDQtMDcwM2UzOWI4N2ZmIiwicGF5ZWUiOnsicGFydHlJZEluZm8iOnsicGFydHlJZFR5cGUiOiJNU0lTRE4iLCJwYXJ0eUlkZW50aWZpZXIiOiIyNzcxMzgwMzkxMyIsImZzcElkIjoicGF5ZWVmc3AifSwicGVyc29uYWxJbmZvIjp7ImNvbXBsZXhOYW1lIjp7fX19LCJwYXllciI6eyJwYXJ0eUlkSW5mbyI6eyJwYXJ0eUlkVHlwZSI6Ik1TSVNETiIsInBhcnR5SWRlbnRpZmllciI6IjI3NzEzODAzOTExIiwiZnNwSWQiOiJwYXllcmZzcCJ9LCJwZXJzb25hbEluZm8iOnsiY29tcGxleE5hbWUiOnt9fX0sImFtb3VudCI6eyJjdXJyZW5jeSI6IlVTRCIsImFtb3VudCI6IjIwMCJ9LCJ0cmFuc2FjdGlvblR5cGUiOnsic2NlbmFyaW8iOiJERVBPU0lUIiwic3ViU2NlbmFyaW8iOiJERVBPU0lUIiwiaW5pdGlhdG9yIjoiUEFZRVIiLCJpbml0aWF0b3JUeXBlIjoiQ09OU1VNRVIiLCJyZWZ1bmRJbmZvIjp7fX19' |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sims",
-  "version": "6.3.3",
+  "version": "7.1.0",
   "description": "A super-simple fsp simulator",
   "main": "src/index.js",
   "author": "ModusBox",

--- a/src/payee/handler.js
+++ b/src/payee/handler.js
@@ -324,7 +324,9 @@ exports.postTransfers = async function (req, h) {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/vnd.interoperability.transfers+json;version=1.0',
-          'FSPIOP-Source': 'payeefsp',
+          // This appears to be causing problems for the central-ledger tests. I don't know why it was changed
+          // 'FSPIOP-Source': 'payeefsp',
+          'FSPIOP-Source': req.headers['fspiop-destination'],
           'FSPIOP-Destination': req.headers['fspiop-source'],
           'Date': new Date().toUTCString(),
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),

--- a/src/payee/handler.js
+++ b/src/payee/handler.js
@@ -324,8 +324,6 @@ exports.postTransfers = async function (req, h) {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/vnd.interoperability.transfers+json;version=1.0',
-          // This appears to be causing problems for the central-ledger tests. I don't know why it was changed
-          // 'FSPIOP-Source': 'payeefsp',
           'FSPIOP-Source': req.headers['fspiop-destination'],
           'FSPIOP-Destination': req.headers['fspiop-source'],
           'Date': new Date().toUTCString(),

--- a/src/payee/routes.js
+++ b/src/payee/routes.js
@@ -181,6 +181,7 @@ module.exports = [
 
   },
   {
+    // This appears to be broken
     method: 'POST',
     path: '/payeefsp/transfers',
     handler: Handler.postTransfers,

--- a/src/payee/routes.js
+++ b/src/payee/routes.js
@@ -181,7 +181,6 @@ module.exports = [
 
   },
   {
-    // This appears to be broken
     method: 'POST',
     path: '/payeefsp/transfers',
     handler: Handler.postTransfers,


### PR DESCRIPTION
Part of #817

For some reason, the `FSPIOP-Source` header was hardcoded to `payeefsp` in some recent changes. This caused issues with the central-ledger not being able to find registered participants, which was causing integration tests to fail on `central-settlement`.

I'm not sure why this changed, but changing this line back fixed my issue.

I also optimized the Dockerfile to better cache layers.

