### PR TITLE
Fix docker workdir naming, bump to 7.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,16 @@
-FROM node:10.15.1-alpine
-
-WORKDIR /opt/simulators
-#COPY logs /opt/simulators/logs
+FROM node:10.15.3-alpine
+WORKDIR /opt/simulator
 
 RUN apk --no-cache add --virtual native-deps \
   g++ gcc libgcc libstdc++ linux-headers make python 
 
-
-COPY package*.json /opt/simulators/
+COPY package*.json /opt/simulator/
 
 RUN npm install --quiet node-gyp -g &&\
   npm install --quiet --production
-
 RUN apk del native-deps
 
-COPY src /opt/simulators/src
-
-
-# Create empty log file
-#RUN touch ./logs/combined.log
-
-# Link the stdout to the application log file
-#RUN ln -sf /dev/stdout ./logs/combined.log
+COPY src /opt/simulator/src
 
 EXPOSE 8444
 CMD ["node", "./src/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sims",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sims",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "A super-simple fsp simulator",
   "main": "src/index.js",
   "author": "ModusBox",


### PR DESCRIPTION
Resolves https://github.com/mojaloop/project/issues/929

- Changes the name of the workdir to be consistent with other projects (docker image name and workdir name should be the same)

