### PR TITLE
Ensure no 'Accept' header is sent in 'PUT' requests, as per mojaloop specification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10.15.3-alpine
 WORKDIR /opt/simulator
 
 RUN apk --no-cache add --virtual native-deps \
-  g++ gcc libgcc libstdc++ linux-headers make python 
+  g++ gcc libgcc libstdc++ linux-headers make python bash
 
 COPY package*.json /opt/simulator/
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Simulators that act as mock payer fsp and payee fsp which interact with the Swit
 
 ## Run in Docker (in Dev)
 
-`$ docker-compose up` or `$docker-compose up --build` to rebuild if source code has been modified.
+`$ docker-compose up` 
+
+ or (to rebuild the docker image if source code has been modified)
+
+`$ docker-compose up --build` 
 
 ## Auditing Dependencies
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Simulators that act as mock payer fsp and payee fsp which interact with the Swit
 
 ## Building Docker image:
 
-`$ VER=v1.0.6-snapshot; docker build -t mojaloop/simulator:$VER .; docker push mojaloop/simulator:$VER`            
+`$ VER=v1.0.6-snapshot; docker build -t mojaloop/simulator:$VER .; docker push mojaloop/simulator:$VER`    
+
+## Run in Docker (in Dev)
+
+`$ docker-compose up` or `$docker-compose up --build` to rebuild if source code has been modified.
 
 ## Auditing Dependencies
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+
+services:
+  simulator:
+    build:
+      context: .
+    container_name: simulator
+    ports:
+      - "8444:8444"
+    environment:
+      - LOG_LEVEL=info
+      - TRANSFERS_ENDPOINT=http://172.17.0.1:3000
+      - TRANSFERS_FULFIL_RESPONSE_DISABLED=false
+      - QUOTES_ENDPOINT=http://172.17.0.1:3002
+    healthcheck:
+      test: ["CMD", "sh", "-c" ,"apk --no-cache add curl", ";", "curl", "http://localhost:8444/health"]
+      timeout: 20s
+      retries: 10
+      interval: 30s

--- a/package-lock.json
+++ b/package-lock.json
@@ -2897,11 +2897,6 @@
         }
       }
     },
-    "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-    },
     "node-rdkafka": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.6.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sims",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -22,6 +22,15 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@grpc/proto-loader": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.1.tgz",
+      "integrity": "sha512-3y0FhacYAwWvyXshH18eDkUI40wT/uGio7MAegzY8lO5+wVsc19+1A7T0pPptae4kl7bdITL+0cHpnAPmryBjQ==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "protobufjs": "^6.8.6"
       }
     },
     "@hapi/accept": {
@@ -502,6 +511,24 @@
         }
       }
     },
+    "@hapi/vision": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@hapi/vision/-/vision-5.5.3.tgz",
+      "integrity": "sha512-jZ00PQSGedO3CKmo6BzA3nXfZrVZKtV1jN1mZizpk5UslvGYKhgmk3dDrHSjmWWTAEqWYeWic1Zf67J9asA7Sg==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
+          "integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg=="
+        }
+      }
+    },
     "@hapi/wreck": {
       "version": "15.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.2.tgz",
@@ -519,64 +546,87 @@
         }
       }
     },
-    "@modusbox/mojaloop-sdk-standard-components": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@modusbox/mojaloop-sdk-standard-components/-/mojaloop-sdk-standard-components-0.0.37.tgz",
-      "integrity": "sha512-L9Klvp7USsQwpFIcGmBjYBVFa5MrtL66h8hMgoP/wUCDnhYjlyTOsf+4m5r9x2bS/ShMz2MkNQ1wUk/SjWf+8Q==",
-      "requires": {
-        "base64url": "^3.0.1",
-        "ilp-packet": "2.2.0",
-        "jsonwebtoken": "^8.5.1",
-        "jws": "^3.2.2",
-        "request": "^2.34",
-        "request-promise-native": "^1.0.7"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
-          "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
-        },
-        "ilp-packet": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
-          "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
-          "requires": {
-            "bignumber.js": "^5.0.0",
-            "extensible-error": "^1.0.2",
-            "long": "^3.2.0",
-            "oer-utils": "^1.3.2"
-          }
-        },
-        "long": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
-        },
-        "oer-utils": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
-          "integrity": "sha1-sqmtvJK8GRVaKgDwRWg9Hm1KyCM="
-        }
-      }
-    },
     "@mojaloop/central-services-error-handling": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.3.0.tgz",
-      "integrity": "sha512-LSqQkI2/2BI7EukrWgOFafk1rBkxrwgNDfJ1NQ1ZqvsJ5/Xuapd2rJbRi2mik5bfjObU43+GBEzWBqIGnZpksQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.4.1.tgz",
+      "integrity": "sha512-HQ54Jo4uI2BJCzaNC5mPvEmHXqd8W0INI/lHJey/8AlbTUhG0WRwSoZ3be3MWDl38O8F293rsC3uKhZSx/pTgA==",
       "requires": {
-        "@modusbox/mojaloop-sdk-standard-components": "0.0.37",
-        "@mojaloop/central-services-shared": "6.4.1",
+        "@mojaloop/central-services-shared": "7.4.5",
+        "@mojaloop/sdk-standard-components": "7.4.0",
         "lodash": "4.17.15"
       },
       "dependencies": {
-        "@mojaloop/central-services-shared": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
-          "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
+        "@mojaloop/central-services-error-handling": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.4.0.tgz",
+          "integrity": "sha512-+2OhkP06q6aR23tqxelHwG/hzA+y10cbPBAC3ovlB0z/n1R90ENek0RKyNcDw0F9ComSmBFiY3k9gOrPYv0w8A==",
           "requires": {
-            "async": "3.1.0",
-            "debug": "4.1.1",
+            "@mojaloop/central-services-shared": "7.4.4",
+            "@mojaloop/sdk-standard-components": "7.4.0",
+            "lodash": "4.17.15"
+          },
+          "dependencies": {
+            "@mojaloop/central-services-error-handling": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.3.0.tgz",
+              "integrity": "sha512-LSqQkI2/2BI7EukrWgOFafk1rBkxrwgNDfJ1NQ1ZqvsJ5/Xuapd2rJbRi2mik5bfjObU43+GBEzWBqIGnZpksQ==",
+              "requires": {
+                "@mojaloop/central-services-shared": "6.4.1",
+                "lodash": "4.17.15"
+              },
+              "dependencies": {
+                "@mojaloop/central-services-shared": {
+                  "version": "6.4.1",
+                  "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
+                  "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
+                  "requires": {
+                    "async": "3.1.0",
+                    "debug": "4.1.1",
+                    "winston": "3.2.1"
+                  }
+                }
+              }
+            },
+            "@mojaloop/central-services-shared": {
+              "version": "7.4.4",
+              "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.4.4.tgz",
+              "integrity": "sha512-BB2iHjFuLbKyN2RUVRb5vPICfkAwJuf1uenCDvJdbl6b8/9ZB83uKyaia8BbIlhzVfv3rAFzH9Z5R3edllwvcw==",
+              "requires": {
+                "@mojaloop/central-services-stream": "6.2.2",
+                "axios": "0.19.0",
+                "catbox": "10.0.6",
+                "catbox-memory": "4.0.1",
+                "glob": "7.1.4",
+                "immutable": "3.8.2",
+                "lodash": "4.17.15",
+                "mustache": "3.0.1",
+                "raw-body": "2.4.1",
+                "uuid4": "1.1.4",
+                "winston": "3.2.1"
+              }
+            },
+            "mustache": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+              "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
+            }
+          }
+        },
+        "@mojaloop/central-services-shared": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.4.5.tgz",
+          "integrity": "sha512-/jaqOF2M4ExfrPxWHF1npT1pZuM6EroYAQxY/nvprhRyFapI+phVsrIw2rXlgNBtcMqH7+z1DaVaN4phwRfyCQ==",
+          "requires": {
+            "@mojaloop/central-services-stream": "6.2.2",
+            "axios": "0.19.0",
+            "catbox": "10.0.6",
+            "catbox-memory": "4.0.1",
+            "glob": "7.1.4",
+            "immutable": "3.8.2",
+            "lodash": "4.17.15",
+            "mustache": "3.0.3",
+            "raw-body": "2.4.1",
+            "uuid4": "1.1.4",
             "winston": "3.2.1"
           }
         }
@@ -620,22 +670,78 @@
       }
     },
     "@mojaloop/central-services-shared": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.4.3.tgz",
-      "integrity": "sha512-TxBv6ihR1B0rTiVjM9j7B9eg5Xvvt5n+tZGE1H1J0Ac/GIrgxWppFuusU3/yzS+xkjBfGWOr8Un/9DHpM7ek7Q==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.4.7.tgz",
+      "integrity": "sha512-62VSo4gWO0UFaDigJsrC022+oyQsYYu+2YiOGXT+FZxpZyuZVj5Y2ZY2emo542rn9/4guAacFFKmv/IqgimXCQ==",
       "requires": {
-        "@mojaloop/central-services-error-handling": "7.3.0",
+        "@mojaloop/central-services-error-handling": "7.4.0",
         "@mojaloop/central-services-stream": "6.2.2",
+        "@mojaloop/event-sdk": "7.4.0",
         "axios": "0.19.0",
         "catbox": "10.0.6",
         "catbox-memory": "4.0.1",
         "glob": "7.1.4",
         "immutable": "3.8.2",
         "lodash": "4.17.15",
-        "mustache": "3.0.1",
+        "mustache": "3.0.3",
         "raw-body": "2.4.1",
         "uuid4": "1.1.4",
         "winston": "3.2.1"
+      },
+      "dependencies": {
+        "@mojaloop/central-services-error-handling": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.4.0.tgz",
+          "integrity": "sha512-+2OhkP06q6aR23tqxelHwG/hzA+y10cbPBAC3ovlB0z/n1R90ENek0RKyNcDw0F9ComSmBFiY3k9gOrPYv0w8A==",
+          "requires": {
+            "@mojaloop/sdk-standard-components": "7.4.0",
+            "lodash": "4.17.15"
+          }
+        },
+        "@mojaloop/central-services-shared": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.4.4.tgz",
+          "integrity": "sha512-BB2iHjFuLbKyN2RUVRb5vPICfkAwJuf1uenCDvJdbl6b8/9ZB83uKyaia8BbIlhzVfv3rAFzH9Z5R3edllwvcw==",
+          "requires": {
+            "@mojaloop/central-services-error-handling": "7.3.0",
+            "@mojaloop/central-services-stream": "6.2.2",
+            "axios": "0.19.0",
+            "catbox": "10.0.6",
+            "catbox-memory": "4.0.1",
+            "glob": "7.1.4",
+            "immutable": "3.8.2",
+            "lodash": "4.17.15",
+            "mustache": "3.0.1",
+            "raw-body": "2.4.1",
+            "uuid4": "1.1.4",
+            "winston": "3.2.1"
+          },
+          "dependencies": {
+            "@mojaloop/central-services-error-handling": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.3.0.tgz",
+              "integrity": "sha512-LSqQkI2/2BI7EukrWgOFafk1rBkxrwgNDfJ1NQ1ZqvsJ5/Xuapd2rJbRi2mik5bfjObU43+GBEzWBqIGnZpksQ==",
+              "requires": {
+                "lodash": "4.17.15"
+              }
+            },
+            "@mojaloop/central-services-shared": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
+              "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
+              "requires": {
+                "async": "3.1.0",
+                "debug": "4.1.1",
+                "winston": "3.2.1"
+              }
+            },
+            "mustache": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+              "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
+            }
+          }
+        }
       }
     },
     "@mojaloop/central-services-stream": {
@@ -691,10 +797,232 @@
         }
       }
     },
+    "@mojaloop/event-sdk": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/event-sdk/-/event-sdk-7.4.0.tgz",
+      "integrity": "sha512-Zgq2g00RJQrsAcZZEgFGy9i+eOPJgYI7hTTrsEXFzadURNeMx6D7Vyy20LSf1Aj/5KYq0p0fSiLYUtXZAin7bA==",
+      "requires": {
+        "@grpc/proto-loader": "0.5.1",
+        "@mojaloop/central-services-shared": "7.2.0",
+        "@types/protobufjs": "6.0.0",
+        "brototype": "0.0.6",
+        "grpc": "1.21.1",
+        "lodash": "4.17.15",
+        "moment": "2.24.0",
+        "parse-strings-in-object": "1.2.0",
+        "protobufjs": "6.8.8",
+        "rc": "1.2.8",
+        "sinon": "7.3.2",
+        "traceparent": "1.0.0",
+        "uuid4": "1.1.4"
+      },
+      "dependencies": {
+        "@modusbox/mojaloop-sdk-standard-components": {
+          "version": "0.0.36",
+          "resolved": "https://registry.npmjs.org/@modusbox/mojaloop-sdk-standard-components/-/mojaloop-sdk-standard-components-0.0.36.tgz",
+          "integrity": "sha512-wtRm+BOvImnkSaq2UkAWWj3SWaSR2c6l8ibrNWNfZXJaGmcaWb+T+caue/XYGTtQyOjL1+q5Qe4P8ppfc6ZRBA==",
+          "requires": {
+            "base64url": "^3.0.1",
+            "ilp-packet": "2.2.0",
+            "jsonwebtoken": "^8.5.1",
+            "jws": "^3.2.2",
+            "request": "^2.34",
+            "request-promise-native": "^1.0.7"
+          }
+        },
+        "@mojaloop/central-services-error-handling": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.2.2.tgz",
+          "integrity": "sha512-nDzMRXF8OlqE0gFGMv3f3jo5Dx7YverVya3REhV6xlmXTCVytSmk2smefNFYloGumMsfcC8QTaiUhTQIU2KJfA==",
+          "requires": {
+            "@modusbox/mojaloop-sdk-standard-components": "0.0.36",
+            "@mojaloop/central-services-shared": "6.4.1",
+            "lodash": "4.17.15"
+          },
+          "dependencies": {
+            "@mojaloop/central-services-shared": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
+              "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
+              "requires": {
+                "async": "3.1.0",
+                "debug": "4.1.1",
+                "winston": "3.2.1"
+              }
+            }
+          }
+        },
+        "@mojaloop/central-services-shared": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.2.0.tgz",
+          "integrity": "sha512-dBjthgRj38GINGn2UaVHykrSaQHt9CUsxmdCEjKMOPXs67wzg7QFJJf7fOouuIqynvJnz7rBM0Df5pyM+k3ICg==",
+          "requires": {
+            "@mojaloop/central-services-error-handling": "7.2.2",
+            "@mojaloop/central-services-stream": "6.2.2",
+            "axios": "0.19.0",
+            "catbox": "10.0.6",
+            "catbox-memory": "4.0.1",
+            "glob": "7.1.4",
+            "immutable": "3.8.2",
+            "lodash": "4.17.15",
+            "mustache": "3.0.1",
+            "raw-body": "2.4.1",
+            "uuid4": "1.1.4",
+            "winston": "3.2.1"
+          }
+        },
+        "ilp-packet": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+          "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
+          "requires": {
+            "bignumber.js": "^5.0.0",
+            "extensible-error": "^1.0.2",
+            "long": "^3.2.0",
+            "oer-utils": "^1.3.2"
+          }
+        },
+        "mustache": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+          "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
+        }
+      }
+    },
+    "@mojaloop/sdk-standard-components": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-7.4.0.tgz",
+      "integrity": "sha512-5bpw0oFuSon9Zd7qNOhWoLozHLBPGqcu0vFhxMcLecSA5UPjyq5JJf3tAcaAtnJspkTMDW/GieI0uCr9pCEJzA==",
+      "requires": {
+        "base64url": "^3.0.1",
+        "ilp-packet": "2.2.0",
+        "jsonwebtoken": "^8.5.1",
+        "jws": "^3.2.2",
+        "request": "^2.34",
+        "request-promise-native": "^1.0.7"
+      },
+      "dependencies": {
+        "ilp-packet": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+          "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
+          "requires": {
+            "bignumber.js": "^5.0.0",
+            "extensible-error": "^1.0.2",
+            "long": "^3.2.0",
+            "oer-utils": "^1.3.2"
+          }
+        }
+      }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
+    "@types/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+    },
+    "@types/node": {
+      "version": "10.14.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
+      "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ=="
+    },
+    "@types/protobufjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/protobufjs/-/protobufjs-6.0.0.tgz",
+      "integrity": "sha512-A27RDExpAf3rdDjIrHKiJK6x8kqqJ4CmoChwtipfhVAn1p7+wviQFFP7dppn8FslSbHtQeVPvi8wNKkDjSYjHw==",
+      "requires": {
+        "protobufjs": "*"
+      }
+    },
     "abab": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
+      "integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw=="
     },
     "acorn": {
       "version": "7.0.0",
@@ -717,28 +1045,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-      "dev": true,
-      "requires": {
-        "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        }
       }
     },
     "ansi-escapes": {
@@ -773,6 +1079,11 @@
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+    },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
@@ -792,6 +1103,15 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+    },
+    "ascli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "requires": {
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -870,9 +1190,9 @@
       }
     },
     "bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
     },
     "bindings": {
       "version": "1.4.0",
@@ -917,53 +1237,9 @@
       },
       "dependencies": {
         "hoek": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
-        }
-      }
-    },
-    "boxen": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
-      "dev": true,
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^2.4.2",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^3.0.0",
-        "term-size": "^1.2.0",
-        "type-fest": "^0.3.0",
-        "widest-line": "^2.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0"
-          }
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
         }
       }
     },
@@ -976,6 +1252,11 @@
         "concat-map": "0.0.1"
       }
     },
+    "brototype": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/brototype/-/brototype-0.0.6.tgz",
+      "integrity": "sha1-mz8HNkeDOXuPHEvuehQZk1ZuS0Q="
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -986,6 +1267,14 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "requires": {
+        "long": "~3"
+      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -1073,18 +1362,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true
-    },
-    "cli-boxes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
-      "dev": true
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -1100,11 +1377,59 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "optional": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color": {
       "version": "3.0.0",
@@ -1155,6 +1480,11 @@
         "color": "3.0.x",
         "text-hex": "1.0.x"
       }
+    },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1273,6 +1603,16 @@
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1343,6 +1683,11 @@
         "enabled": "1.0.x",
         "kuler": "1.0.x"
       }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -1511,9 +1856,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
-      "integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
+      "integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1523,9 +1868,9 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^6.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -1564,15 +1909,15 @@
       }
     },
     "eslint-config-standard": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.0.1.tgz",
-      "integrity": "sha512-1RWsAKTDTZgA8bIM6PSC9aTGDAUlKqNkYNJlTZ5xYD/HYkIM6GlcefFvgcJ8xi0SWG5203rttKYX28zW+rKNOg==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.0.1.tgz",
-      "integrity": "sha512-SDnpVLSzTcT0eLNTG7s8ffRi3WadBBpw+pFsiBj4BcrHOFOga9O/7mjtNRyPgetmsiDPWGxsiS4UdJLZhaIukA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
+      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -1630,12 +1975,12 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
-      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz",
+      "integrity": "sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^1.3.0",
+        "eslint-utils": "^1.4.2",
         "regexpp": "^2.0.1"
       }
     },
@@ -1856,34 +2201,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
       "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
     },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2060,29 +2377,10 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "funding": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/funding/-/funding-1.0.8.tgz",
-      "integrity": "sha512-M4yYVbIgS9jxKY0XS89DDpsiMHe+JiwavRaXCmJxNmhJhVPEi8KigfP6mP69oOWaTDrCfrF4rE36OhGfoHkTTQ==",
-      "dev": true,
-      "requires": {
-        "boxen": "^3.2.0",
-        "chalk": "^2.4.2",
-        "ci-info": "^2.0.0",
-        "term-size": "^2.1.0",
-        "word-wrap": "^1.2.3"
-      }
-    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
       "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
     "getpass": {
@@ -2126,6 +2424,443 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
+    "grpc": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.21.1.tgz",
+      "integrity": "sha512-PFsZQazf62nP05a0xm23mlImMuw5oVlqF/0zakmsdqJgvbABe+d6VThY2PfhqJmWEL/FhQ6QNYsxS5EAM6++7g==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clone": "^4.5.0",
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.13.0",
+        "protobufjs": "^5.0.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        },
+        "needle": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.13.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "protobufjs": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+          "requires": {
+            "ascli": "~1",
+            "bytebuffer": "~5",
+            "glob": "^7.0.5",
+            "yargs": "^3.10.0"
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.4",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true
+        }
+      }
+    },
     "handlebars": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
@@ -2163,9 +2898,9 @@
       }
     },
     "hapi-swagger": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/hapi-swagger/-/hapi-swagger-10.1.0.tgz",
-      "integrity": "sha512-mOEvz9xmonhBfKpNhfhSVYLKK1DjvqaE7jgupH68z24p/NDyhSwKGXad0w+RPx4nuGmPBW1pvVggaIsSclmZGA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/hapi-swagger/-/hapi-swagger-10.1.1.tgz",
+      "integrity": "sha512-OT0ycz3rBxLgpdara3dP7BJ8H9ZSgy08PicRPJuYbnGD2+DxSuSu93xOlMWDx9hG9sApsN175rO7wBu+SE7YGA==",
       "requires": {
         "@hapi/boom": "^7.1.1",
         "@hapi/hoek": "^6.1.2",
@@ -2308,13 +3043,28 @@
       "dev": true
     },
     "ilp-packet": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.0.8.tgz",
-      "integrity": "sha512-bi199aq5ptPm+fLybkManwDYZ6nuxxtSZtvTU1xPkzmIoLxAIqc9kBWqT7SXsCUsZ3Py3bZL2RZ79BqjmK5Nvw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.0.9.tgz",
+      "integrity": "sha512-tw4uuLQDIJSMFLmNSbQ1ImeW/Yfb3p+naVJe3ghdPwJQWT3Qd48ghAYyz5oo8Oa3evw6TBipNIV0iO+Mz5Zy+g==",
       "requires": {
         "extensible-error": "^1.0.2",
-        "long": "^4.0.0",
-        "oer-utils": "^4.0.0"
+        "oer-utils": "^5.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "oer-utils": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-5.0.1.tgz",
+          "integrity": "sha512-/+b8EC7RsNBkK+0weoUD55dKa5K2kUAIMM6KY62ssOtu7EyCcqi7idOesaXoUZEYezeZrvu09MOuias/RWVubw==",
+          "requires": {
+            "@types/long": "^4.0.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "immutable": {
@@ -2352,6 +3102,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "inquirer": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
@@ -2372,6 +3127,11 @@
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "is-arrayish": {
       "version": "0.3.2",
@@ -2484,11 +3244,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "items": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-      "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
     },
     "joi": {
       "version": "13.7.0",
@@ -2618,6 +3373,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
+    },
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -2643,6 +3403,14 @@
       "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
       "requires": {
         "colornames": "^1.1.1"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
       }
     },
     "levn": {
@@ -2680,6 +3448,16 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2743,10 +3521,15 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg=="
+    },
     "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -2818,9 +3601,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -2850,9 +3633,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mustache": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
-      "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.3.tgz",
+      "integrity": "sha512-vM5FkMHamTYmVYeAujypihuPrJQDtaUIlKeeVb1AMJ73OZLtWiF7GprqrjxD0gJWT53W9JfqXxf97nXQjMQkqA=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -2880,6 +3663,18 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-cache": {
       "version": "4.2.1",
@@ -2956,6 +3751,11 @@
         "path-key": "^2.0.0"
       }
     },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -3021,12 +3821,9 @@
       }
     },
     "oer-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-4.0.0.tgz",
-      "integrity": "sha512-WxX0gNGSS0Lzig4IdliHlIQ03PVTpIuLFbOAag5lJrx1hWNG3f/yhx3QOmORpoXe2e53HZbeet8qoOAsiWz5BQ==",
-      "requires": {
-        "bignumber.js": "^7.2.1"
-      }
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
+      "integrity": "sha1-sqmtvJK8GRVaKgDwRWg9Hm1KyCM="
     },
     "once": {
       "version": "1.4.0",
@@ -3065,6 +3862,13 @@
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        }
       }
     },
     "optionator": {
@@ -3089,6 +3893,19 @@
         }
       }
     },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -3099,12 +3916,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
@@ -3149,6 +3960,11 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse-strings-in-object": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parse-strings-in-object/-/parse-strings-in-object-1.2.0.tgz",
+      "integrity": "sha512-lI8XgBWZ5COL0G2G6MsLqPSc4X/SnYPw5jGDiins/qzdOdlY493j/niCY9UiJqWjDoeY20k7vhEXvKRHTy6Dfw=="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -3169,6 +3985,21 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
     },
     "path-type": {
       "version": "3.0.0",
@@ -3356,6 +4187,33 @@
         "react-is": "^16.8.1"
       }
     },
+    "protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        }
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -3395,6 +4253,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "random-poly-fill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/random-poly-fill/-/random-poly-fill-1.0.1.tgz",
+      "integrity": "sha512-bMOL0hLfrNs52+EHtIPIXxn2PxYwXb0qjnKruTjXiM/sKfYqj506aB2plFwWW1HN+ri724bAVVGparh4AtlJKw=="
+    },
     "raw-body": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
@@ -3422,6 +4285,24 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -3685,6 +4566,20 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "sinon": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      }
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -3777,20 +4672,19 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "standard": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-14.0.2.tgz",
-      "integrity": "sha512-2Rjsc+B1zaXiQVfUlH7n+ZIrCpxxAaVEItps2lBQUQLuyCH/Vc788w6q16PMK4ezPA61jm8A1vzBnBwcokGOgQ==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-14.1.0.tgz",
+      "integrity": "sha512-jeRuTKtBJ9dI1kyYiC1RBbiVzSjGIbswIlO1OQMvnXizO94gEk2Yr80W5e/HmCWWbjzBqJBa+0JGazgL7JN2jQ==",
       "dev": true,
       "requires": {
-        "eslint": "~6.1.0",
-        "eslint-config-standard": "14.0.1",
-        "eslint-config-standard-jsx": "8.0.1",
+        "eslint": "~6.2.2",
+        "eslint-config-standard": "14.1.0",
+        "eslint-config-standard-jsx": "8.1.0",
         "eslint-plugin-import": "~2.18.0",
         "eslint-plugin-node": "~9.1.0",
         "eslint-plugin-promise": "~4.2.1",
         "eslint-plugin-react": "~7.14.2",
         "eslint-plugin-standard": "~4.0.0",
-        "funding": "^1.0.0",
         "standard-engine": "^12.0.0"
       }
     },
@@ -3804,14 +4698,6 @@
         "get-stdin": "^7.0.0",
         "minimist": "^1.1.0",
         "pkg-conf": "^3.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "statuses": {
@@ -3889,12 +4775,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
     },
     "strip-json-comments": {
       "version": "3.0.1",
@@ -3982,12 +4862,6 @@
         "bintrees": "1.0.1"
       }
     },
-    "term-size": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.1.0.tgz",
-      "integrity": "sha512-I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg==",
-      "dev": true
-    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -4058,6 +4932,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "traceparent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/traceparent/-/traceparent-1.0.0.tgz",
+      "integrity": "sha512-b/hAbgx57pANQ6cg2eBguY3oxD6FGVLI1CC2qoi01RmHR7AYpQHPXTig9FkzbWohEsVuHENZHP09aXuw3/LM+w==",
+      "requires": {
+        "random-poly-fill": "^1.0.1"
+      }
+    },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -4090,6 +4972,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.3.1",
@@ -4177,34 +5064,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "vision": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/vision/-/vision-5.4.4.tgz",
-      "integrity": "sha512-jFeH7pU/ODYmTOpY5jutMKU/fDr+P621WYEnWgqwDikxutBWJ+koxlgGnkZQoKY6JlYdY4Awo+rPN3DNdTeDKg==",
-      "requires": {
-        "boom": "7.x.x",
-        "hoek": "6.x.x",
-        "items": "2.x.x",
-        "joi": "14.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
-        },
-        "joi": {
-          "version": "14.3.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-          "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
-          "requires": {
-            "hoek": "6.x.x",
-            "isemail": "3.x.x",
-            "topo": "3.x.x"
-          }
-        }
-      }
-    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -4242,14 +5101,10 @@
         "isexe": "^2.0.0"
       }
     },
-    "widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^2.1.1"
-      }
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "winston": {
       "version": "3.2.1",
@@ -4315,16 +5170,52 @@
         }
       }
     },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -4346,10 +5237,67 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "requires": {
+        "camelcase": "^2.0.1",
+        "cliui": "^3.0.3",
+        "decamelize": "^1.1.1",
+        "os-locale": "^1.4.0",
+        "string-width": "^1.0.1",
+        "window-size": "^0.1.4",
+        "y18n": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "yargs-parser": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sims",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "A super-simple fsp simulator",
   "main": "src/index.js",
   "author": "ModusBox",
@@ -33,27 +33,27 @@
     "@hapi/inert": "5.2.1",
     "@hapi/joi": "15.1.1",
     "@hapi/joi-date": "1.3.0",
-    "@mojaloop/central-services-error-handling": "7.3.0",
+    "@mojaloop/central-services-error-handling": "7.4.1",
     "@mojaloop/central-services-metrics": "5.2.0",
-    "@mojaloop/central-services-shared": "7.4.3",
-    "axios": "^0.19.0",
+    "@mojaloop/central-services-shared": "7.4.7",
+    "axios": "0.19.0",
     "base64url": "3.0.1",
     "blipp": "4.0.0",
     "five-bells-condition": "5.0.1",
     "glob": "7.1.4",
     "hapi-good-winston": "3.0.0",
     "hapi-openapi": "1.2.2",
-    "hapi-swagger": "10.1.0",
-    "ilp-packet": "3.0.8",
+    "hapi-swagger": "10.1.1",
+    "ilp-packet": "3.0.9",
     "joi-currency-code": "2.0.2",
     "node-cache": "4.2.1",
     "npm-run-all": "4.1.5",
     "prom-client": "11.5.3",
-    "vision": "5.4.4"
+    "@hapi/vision": "5.5.3"
   },
   "devDependencies": {
     "pre-commit": "1.2.2",
-    "standard": "14.0.2",
+    "standard": "14.1.0",
     "npm-audit-resolver": "1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@mojaloop/central-services-error-handling": "7.3.0",
     "@mojaloop/central-services-metrics": "5.2.0",
     "@mojaloop/central-services-shared": "7.4.3",
+    "axios": "^0.19.0",
     "base64url": "3.0.1",
     "blipp": "4.0.0",
     "five-bells-condition": "5.0.1",
@@ -45,7 +46,6 @@
     "ilp-packet": "3.0.8",
     "joi-currency-code": "2.0.2",
     "node-cache": "4.2.1",
-    "node-fetch": "2.6.0",
     "npm-run-all": "4.1.5",
     "prom-client": "11.5.3",
     "vision": "5.4.4"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "Miguel de Barros <miguel.debarros@modusbox.com>",
     "Murthy Kakarlamudi <murthy@modusbox.com>",
     "Rajiv Mothilal <rajiv.mothilal@modusbox.com>",
-    "Sri Miriyala <sridevi.miriyala@modusbox.com>"
+    "Sri Miriyala <sridevi.miriyala@modusbox.com>",
+    "Steven Oderayi <steven.oderayi@modusbox.com>"
   ],
   "repository": {
     "type": "git",

--- a/src/acceptheaderpayee/handler.js
+++ b/src/acceptheaderpayee/handler.js
@@ -28,6 +28,7 @@ const callbacks = new NodeCache()
 const request = require('axios')
 const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
 
@@ -56,7 +57,7 @@ exports.metadata = function (request, h) {
   return h.response({
     directory: 'localhost',
     urls: extractUrls(request)
-  }).code(200)
+  }).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /participants
@@ -79,7 +80,7 @@ exports.putParticipantsByTypeId = function (request, h) {
   myCache.set(request.params.id, request.payload)
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'putParticipantsByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.postPartiesByTypeAndId = function (request, h) {
@@ -93,7 +94,7 @@ exports.postPartiesByTypeAndId = function (request, h) {
   myCache.set(request.params.id, request.payload)
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'postPartiesByTypeAndId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getPartiesByTypeAndId = function (req, h) {
@@ -136,8 +137,8 @@ exports.getPartiesByTypeAndId = function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/parties/${req.params.type}/${req.params.id}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         httpsAgent: new https.Agent({
           rejectUnauthorized: false
@@ -148,7 +149,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       Logger.info((new Date().toISOString()), 'Executing PUT', url)
       const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -160,7 +161,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
     }
   })()
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.postQuotes = function (req, h) {
@@ -225,8 +226,8 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         httpsAgent: new https.Agent({
           rejectUnauthorized: false
@@ -236,7 +237,7 @@ exports.postQuotes = function (req, h) {
       Logger.info((new Date().toISOString()), 'Executing PUT', url)
       const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -254,7 +255,7 @@ exports.postQuotes = function (req, h) {
       // rq.sendError(url, asyncResponses.serverError, rq.defaultHeaders(requesterName, 'participants'), {logger});
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.postTransfers = async function (req, h) {
@@ -307,8 +308,8 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         httpsAgent: new https.Agent({
           rejectUnauthorized: false
@@ -319,7 +320,7 @@ exports.postTransfers = async function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
       const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }
@@ -357,7 +358,7 @@ exports.postTransfers = async function (req, h) {
     })
   }
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putTransfersById = function (request, h) {
@@ -379,7 +380,7 @@ exports.putTransfersById = function (request, h) {
   callbacks.set(request.params.id, incomingRequest)
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'putTransfersById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putTransfersByIdError = function (request, h) {
@@ -400,7 +401,7 @@ exports.putTransfersByIdError = function (request, h) {
   callbacks.set(request.params.id, incomingRequest)
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'putTransfersByIdError', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getcorrelationId = function (request, h) {
@@ -413,7 +414,7 @@ exports.getcorrelationId = function (request, h) {
   Logger.info(`IN PAYEEFSP:: Final response for GET /acceptheaderpayeefsp/correlationid/${request.params.id}, CACHE: [${JSON.stringify(myCache.get(request.params.id))}`)
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getcorrelationId' })
-  return h.response(myCache.get(request.params.id)).code(202)
+  return h.response(myCache.get(request.params.id)).code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -429,7 +430,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -445,5 +446,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/acceptheaderpayee/routes.js
+++ b/src/acceptheaderpayee/routes.js
@@ -52,7 +52,6 @@ module.exports = [
     path: '/acceptheaderpayeefsp/parties/{type}/{id}',
     handler: Handler.postPartiesByTypeAndId,
     config: {
-      // id: 'add_parties',
       tags: tags,
       auth: null,
       description: 'Transfer API.',
@@ -189,7 +188,6 @@ module.exports = [
     path: '/acceptheaderpayeefsp/transfers',
     handler: Handler.postTransfers,
     config: {
-      // id: 'transfers',
       tags: tags,
       auth: null,
       description: 'Transfer API.',
@@ -240,9 +238,7 @@ module.exports = [
     path: '/acceptheaderpayeefsp/transfers/{id}',
     handler: Handler.putTransfersById,
     config: {
-      // id: 'transfer_fulfilment',
       tags: tags,
-      // auth: Auth.strategy(),
       description: 'Fulfil a transfer',
       payload: {
         failAction: 'error'
@@ -283,7 +279,6 @@ module.exports = [
     path: '/acceptheaderpayeefsp/transfers/{id}/error',
     handler: Handler.putTransfersByIdError,
     options: {
-      // id: 'transfer_abort',
       tags: tags,
       description: 'Abort a transfer',
       payload: {

--- a/src/acceptheaderpayee/routes.js
+++ b/src/acceptheaderpayee/routes.js
@@ -1,0 +1,351 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Steven Oderayi <steven.oderayi@modusbox.com>
+ --------------
+ ******/
+
+const Handler = require('./handler')
+const tags = ['api', 'metadata']
+const BaseJoi = require('joi-currency-code')(require('@hapi/joi'))
+const Extension = require('@hapi/joi-date')
+const Joi = BaseJoi.extend(Extension)
+const transferState = ['RECEIVED', 'RESERVED', 'COMMITTED', 'ABORTED', 'SETTLED']
+const partyIdTypeEnum = ['MSISDN', 'EMAIL', 'PERSONAL_ID', 'BUSINESS', 'DEVICE', 'ACCOUNT_ID', 'IBAN', 'ALIAS']
+
+module.exports = [
+  {
+    method: 'GET',
+    path: '/acceptheaderpayeefsp/',
+    handler: Handler.metadata,
+    options: {
+      tags: tags,
+      description: 'Metadata'
+    }
+  },
+  {
+    method: 'PUT',
+    path: '/acceptheaderpayeefsp/participants/{type}/{id}',
+    handler: Handler.putParticipantsByTypeId,
+    options: {
+      tags: tags,
+      description: 'Callback for adding participant'
+    }
+  },
+  {
+    method: 'POST',
+    path: '/acceptheaderpayeefsp/parties/{type}/{id}',
+    handler: Handler.postPartiesByTypeAndId,
+    config: {
+      // id: 'add_parties',
+      tags: tags,
+      auth: null,
+      description: 'Transfer API.',
+      payload: {
+        failAction: 'error',
+        output: 'data'
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/acceptheaderpayeefsp/parties/{type}/{id}',
+    handler: Handler.getPartiesByTypeAndId,
+    options: {
+      tags: tags,
+      description: 'Add users to payer simulator',
+      validate: {
+        headers: Joi.object({
+          'content-type': Joi.string().required().regex(/application\/vnd.interoperability[.]/),
+          date: Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
+          'x-forwarded-for': Joi.string().optional(),
+          'fspiop-source': Joi.string().required(),
+          'fspiop-destination': Joi.string().optional(),
+          'fspiop-encryption': Joi.string().optional(),
+          'fspiop-signature': Joi.string().optional(),
+          'fspiop-uri': Joi.string().optional(),
+          'fspiop-http-method': Joi.string().optional(),
+          traceparent: Joi.string().optional(),
+          tracestate: Joi.string().optional()
+        }).unknown(false).options({ stripUnknown: true }),
+        failAction: (request, h, err) => { throw err }
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: '/acceptheaderpayeefsp/quotes',
+    handler: Handler.postQuotes,
+    options: {
+      tags: tags,
+      description: 'Add users to payer simulator',
+      payload: {
+        failAction: 'error'
+      },
+      validate: {
+        headers: Joi.object({
+          accept: Joi.string().optional().regex(/application\/vnd.interoperability[.]/),
+          'content-type': Joi.string().required().regex(/application\/vnd.interoperability[.]/),
+          'content-length': Joi.number().max(5242880),
+          date: Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
+          'x-forwarded-for': Joi.string().optional(),
+          'fspiop-source': Joi.string().required(),
+          'fspiop-destination': Joi.string().required(),
+          'fspiop-encryption': Joi.string().optional(),
+          'fspiop-signature': Joi.string().optional(),
+          'fspiop-uri': Joi.string().optional(),
+          'fspiop-http-method': Joi.string().optional(),
+          traceparent: Joi.string().optional(),
+          tracestate: Joi.string().optional()
+        }).unknown(false).options({ stripUnknown: true }),
+        payload: {
+          quoteId: Joi.string().guid().required().description('Id of quote').label('@ Quote Id must be in a valid GUID format. @'),
+          transactionId: Joi.string().guid().required().description('Id of transaction').label('@ Transaction Id must be in a valid GUID format. @'),
+          transactionRequestId: Joi.string().guid().optional().description('Id of transaction request').label('@ Transaction Request Id must be in a valid GUID format. @'),
+          payer: Joi.object().keys({
+            partyIdInfo: Joi.object().keys({
+              partyIdType: Joi.string().required().valid(partyIdTypeEnum).description('Type of the identifier. ').label('@ Type of the identifier.  @'),
+              partyIdentifier: Joi.string().required().min(1).max(32).description('An identifier for the Party.').label('@ An identifier for the Party. @'),
+              partySubIdOrType: Joi.string().optional().min(1).max(32).description('A sub-identifier or sub-type for the Party.').label('@ A sub-identifier or sub-type for the Party. @'),
+              fspId: Joi.string().optional().min(1).max(32).description('FSP ID ').label('@ FSP ID  @')
+            }).required().description('Party Id type, id, sub ID or type, and FSP Id.').label('@ Party Id type, id, sub ID or type, and FSP Id. @'),
+            merchantClassificationCode: Joi.string().optional().min(1).max(32).description('Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.').label('@ Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments. @'),
+            name: Joi.string().optional().min(1).max(32).description('Display name of the Party, could be a real name or a nick name.').label('@ Display name of the Party, could be a real name or a nick name. @'),
+            personalInfo: Joi.object().keys({
+              complexName: Joi.object().keys({
+                firstName: Joi.string().required().regex(/^(?!\s*$)[\w .,'-]{1,128}$/).description('Party’s first name.').label('@ Party’s first name. @'),
+                middleName: Joi.string().optional().regex(/^(?!\s*$)[\w .,'-]{1,128}$/).description('Party’s middle name.').label('@ Party’s middle name. @'),
+                lastName: Joi.string().required().regex(/^(?!\s*$)[\w .,'-]{1,128}$/).description('Party ’s last name.').label('@ Party ’s last name. @')
+              }).optional().description('Amount of the transfer').label('@ Supplied amount fails to match the required format. @'),
+              dateOfBirth: Joi.string().optional().min(1).max(32).description('Financial Service Provider of Payee').label('@ A valid Payee FSP number must be supplied. @')
+            }).optional().description('Personal information used to verify identity of Party such as first, middle, last name and date of birth.').label('@ Personal information used to verify identity of Party such as first, middle, last name and date of birth. @')
+          }).required().description('Information about the Payer in the proposed financial transaction.').label('@ Information about the Payer in the proposed financial transaction. @'),
+          payee: Joi.object().keys({
+            partyIdInfo: Joi.object().keys({
+              partyIdType: Joi.string().required().valid(partyIdTypeEnum).description('Type of the identifier. ').label('@ Type of the identifier.  @'),
+              partyIdentifier: Joi.string().required().min(1).max(32).description('An identifier for the Party.').label('@ An identifier for the Party. @'),
+              partySubIdOrType: Joi.string().optional().min(1).max(32).description('A sub-identifier or sub-type for the Party.').label('@ A sub-identifier or sub-type for the Party. @'),
+              fspId: Joi.string().optional().min(1).max(32).description('FSP ID ').label('@ FSP ID  @')
+            }).required().description('Party Id type, id, sub ID or type, and FSP Id.').label('@ Party Id type, id, sub ID or type, and FSP Id. @'),
+            merchantClassificationCode: Joi.string().optional().min(1).max(32).description('Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.').label('@ Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments. @'),
+            name: Joi.string().optional().min(1).max(32).description('Display name of the Party, could be a real name or a nick name.').label('@ Display name of the Party, could be a real name or a nick name. @'),
+            personalInfo: Joi.object().keys({
+              complexName: Joi.object().keys({
+                firstName: Joi.string().required().regex(/^(?!\s*$)[\w .,'-]{1,128}$/).description('Party’s first name.').label('@ Party’s first name. @'),
+                middleName: Joi.string().optional().regex(/^(?!\s*$)[\w .,'-]{1,128}$/).description('Party’s middle name.').label('@ Party’s middle name. @'),
+                lastName: Joi.string().required().regex(/^(?!\s*$)[\w .,'-]{1,128}$/).description('Party ’s last name.').label('@ Party ’s last name. @')
+              }).optional().description('Amount of the transfer').label('@ Supplied amount fails to match the required format. @'),
+              dateOfBirth: Joi.string().optional().min(1).max(32).description('Financial Service Provider of Payee').label('@ A valid Payee FSP number must be supplied. @')
+            }).optional().description('Personal information used to verify identity of Party such as first, middle, last name and date of birth.').label('@ Personal information used to verify identity of Party such as first, middle, last name and date of birth. @')
+          }).required().description('Information about the Payer in the proposed financial transaction.').label('@ Information about the Payer in the proposed financial transaction. @'),
+          amountType: Joi.string().required().valid('SEND', 'RECEIVE').description('SEND for sendAmount, RECEIVE for receiveAmount').label('@ SEND for sendAmount, RECEIVE for receiveAmount. @'),
+          amount: Joi.object().keys({
+            currency: Joi.string().required().currency().description('Currency of the transfer').label('@ Currency needs to be a valid ISO 4217 currency code. @'),
+            amount: Joi.string().required().regex(/^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$/).description('Amount of the transfer')
+          }).required().description('Amount of the transfer').label('@ Supplied amount fails to match the required format. @'),
+          fees: Joi.object().keys({
+            currency: Joi.string().required().currency().description('Currency of the transfer').label('@ Currency needs to be a valid ISO 4217 currency code. @'),
+            amount: Joi.string().required().regex(/^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$/).description('Amount of the transfer')
+          }).optional().description('Amount of the transfer').label('@ Supplied fees fails to match the required format. @'),
+          transactionType: Joi.object().keys({
+            scenario: Joi.string().required().valid('DEPOSIT', 'WITHDRAWAL', 'TRANSFER', 'PAYMENT').description('One of Deposit, withdrawal, refund').label('@ Supplied value should be one of DEPOSIT', 'WITHDRAWAL', 'TRANSFER', 'PAYMENT. @'),
+            subScenario: Joi.string().optional().regex(/^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$/).description('Possible sub-scenario, defined locally within the scheme.'),
+            initiator: Joi.string().required().valid('PAYER', 'PAYEE').description('Who is initiating the transaction: Payer or Payee').label('@ Who is initiating the transaction: Payer or Payee. @'),
+            initiatorType: Joi.string().required().valid('CONSUMER', 'AGENT', 'BUSINESS', 'DEVICE').description('Consumer, agent, business,'),
+            refundInfo: Joi.string().optional().currency().description('Extra information specific to a refund scenario. Should only be populated if scenario is REFUND').label('@ Extra information specific to a refund scenario. Should only be populated if scenario is REFUND. @'),
+            balanceOfPayments: Joi.string().optional().regex(/^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$/).description('Balance of Payments code')
+          }).required().description('Amount of the transfer').label('@ Supplied amount fails to match the required format. @'),
+          note: Joi.string().optional().regex(/^[A-Za-z0-9-_]+[=]{0,2}$/).min(1).max(32768).description('Memo that will be attached to the transaction.').label('@ Supplied value does not match the required format. @'),
+          expiration: Joi.string().optional().regex(/^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$/).description('When the transfer expires').label('@ A valid transfer expiry date must be supplied. @'),
+          extensionList: Joi.object().keys({
+            extension: Joi.array().items(Joi.object().keys({
+              key: Joi.string().required().min(1).max(32).description('Key').label('@ Supplied key fails to match the required format. @'),
+              value: Joi.string().required().min(1).max(128).description('Value').label('@ Supplied key value fails to match the required format. @')
+            })).required().min(1).max(16).description('extension')
+          }).optional().description('Extension list')
+        },
+        failAction: (request, h, err) => { throw err }
+      }
+    }
+
+  },
+  {
+    method: 'POST',
+    path: '/acceptheaderpayeefsp/transfers',
+    handler: Handler.postTransfers,
+    config: {
+      // id: 'transfers',
+      tags: tags,
+      auth: null,
+      description: 'Transfer API.',
+      payload: {
+        failAction: 'error',
+        output: 'data'
+      },
+      validate: {
+        headers: Joi.object({
+          accept: Joi.string().optional().regex(/application\/vnd.interoperability[.]/),
+          'content-type': Joi.string().required().regex(/application\/vnd.interoperability[.]/),
+          'content-length': Joi.number().max(5242880),
+          date: Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
+          'x-forwarded-for': Joi.string().optional(),
+          'fspiop-source': Joi.string().required(),
+          'fspiop-destination': Joi.string().required(),
+          'fspiop-encryption': Joi.string().optional(),
+          'fspiop-signature': Joi.string().optional(),
+          'fspiop-uri': Joi.string().optional(),
+          'fspiop-http-method': Joi.string().optional(),
+          traceparent: Joi.string().optional(),
+          tracestate: Joi.string().optional()
+        }).unknown(false).options({ stripUnknown: true }),
+        payload: {
+          transferId: Joi.string().guid().required().description('Id of transfer').label('@ Transfer Id must be in a valid GUID format. @'),
+          payeeFsp: Joi.string().required().min(1).max(32).description('Financial Service Provider of Payee').label('@ A valid Payee FSP number must be supplied. @'),
+          payerFsp: Joi.string().required().min(1).max(32).description('Financial Service Provider of Payer').label('@ A valid Payer FSP number must be supplied. @'),
+          amount: Joi.object().keys({
+            currency: Joi.string().required().currency().description('Currency of the transfer').label('@ Currency needs to be a valid ISO 4217 currency code. @'),
+            amount: Joi.string().required().regex(/^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$/).description('Amount of the transfer')
+          }).required().description('Amount of the transfer').label('@ Supplied amount fails to match the required format. @'),
+          ilpPacket: Joi.string().required().regex(/^[A-Za-z0-9-_]+[=]{0,2}$/).min(1).max(32768).description('ilp packet').label('@ Supplied ILPPacket fails to match the required format. @'),
+          condition: Joi.string().required().trim().max(48).regex(/^[A-Za-z0-9-_]{43}$/).description('Condition of transfer').label('@ A valid transfer condition must be supplied. @'),
+          expiration: Joi.string().required().regex(/^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$/).description('When the transfer expires').label('@ A valid transfer expiry date must be supplied. @'),
+          extensionList: Joi.object().keys({
+            extension: Joi.array().items(Joi.object().keys({
+              key: Joi.string().required().min(1).max(32).description('Key').label('@ Supplied key fails to match the required format. @'),
+              value: Joi.string().required().min(1).max(128).description('Value').label('@ Supplied key value fails to match the required format. @')
+            })).required().min(1).max(16).description('extension')
+          }).optional().description('Extension list')
+        },
+        failAction: (request, h, err) => { throw err }
+      }
+    }
+  },
+  {
+    method: 'PUT',
+    path: '/acceptheaderpayeefsp/transfers/{id}',
+    handler: Handler.putTransfersById,
+    config: {
+      // id: 'transfer_fulfilment',
+      tags: tags,
+      // auth: Auth.strategy(),
+      description: 'Fulfil a transfer',
+      payload: {
+        failAction: 'error'
+      },
+      validate: {
+        headers: Joi.object({
+          'content-type': Joi.string().required().regex(/application\/vnd.interoperability[.]/),
+          date: Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
+          'x-forwarded-for': Joi.string().optional(),
+          'fspiop-source': Joi.string().required(),
+          'fspiop-destination': Joi.string().required(),
+          'fspiop-encryption': Joi.string().optional(),
+          'fspiop-signature': Joi.string().optional(),
+          'fspiop-uri': Joi.string().optional(),
+          'fspiop-http-method': Joi.string().optional(),
+          traceparent: Joi.string().optional(),
+          tracestate: Joi.string().optional()
+        }).unknown(false).options({ stripUnknown: true }),
+        params: {
+          id: Joi.string().required().description('path')
+        },
+        payload: {
+          fulfilment: Joi.string().regex(/^[A-Za-z0-9-_]{43}$/).max(48).description('fulfilment of the transfer').label('@ Invalid transfer fulfilment description. @'),
+          completedTimestamp: Joi.string().regex(/^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$/).description('When the transfer was completed').label('@ A valid transfer completion date must be supplied. @'),
+          transferState: Joi.string().required().valid(transferState).description('State of the transfer').label('@ Invalid transfer state given. @'),
+          extensionList: Joi.object().keys({
+            extension: Joi.array().items(Joi.object().keys({
+              key: Joi.string().required().min(1).max(32).description('Key').label('@ Supplied key fails to match the required format. @'),
+              value: Joi.string().required().min(1).max(128).description('Value').label('@ Supplied key value fails to match the required format. @')
+            })).required().min(1).max(16).description('extension')
+          }).optional().description('Extension list')
+        }
+      }
+    }
+  },
+  {
+    method: 'PUT',
+    path: '/acceptheaderpayeefsp/transfers/{id}/error',
+    handler: Handler.putTransfersByIdError,
+    options: {
+      // id: 'transfer_abort',
+      tags: tags,
+      description: 'Abort a transfer',
+      payload: {
+        failAction: 'error'
+      },
+      validate: {
+        headers: Joi.object({
+          'content-type': Joi.string().required().regex(/application\/vnd.interoperability[.]/),
+          date: Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
+          'x-forwarded-for': Joi.string().optional(),
+          'fspiop-source': Joi.string().required(),
+          'fspiop-destination': Joi.string().optional(),
+          'fspiop-encryption': Joi.string().optional(),
+          'fspiop-signature': Joi.string().optional(),
+          'fspiop-uri': Joi.string().optional(),
+          'fspiop-http-method': Joi.string().optional(),
+          traceparent: Joi.string().optional(),
+          tracestate: Joi.string().optional()
+        }).unknown(false).options({ stripUnknown: true }),
+        params: {
+          id: Joi.string().required().description('path')
+        },
+        payload: {
+          errorInformation: Joi.object().keys({
+            errorDescription: Joi.string().required(),
+            errorCode: Joi.string().required().regex(/^[0-9]{4}/),
+            extensionList: Joi.object().keys({
+              extension: Joi.array().items(Joi.object().keys({
+                key: Joi.string().required().min(1).max(32).description('Key').label('@ Supplied key fails to match the required format. @'),
+                value: Joi.string().required().min(1).max(128).description('Value').label('@ Supplied key value fails to match the required format. @')
+              })).required().min(1).max(16).description('extension')
+            }).optional().description('Extension list')
+          }).required().description('Error information')
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/acceptheaderpayeefsp/correlationid/{id}',
+    handler: Handler.getcorrelationId,
+    options: {
+      tags: tags,
+      description: 'Get details based on correlationid'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/acceptheaderpayeefsp/requests/{id}',
+    handler: Handler.getRequestById,
+    options: {
+      tags: tags,
+      description: 'Get details based on request id'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/acceptheaderpayeefsp/callbacks/{id}',
+    handler: Handler.getCallbackById,
+    options: {
+      tags: tags,
+      description: 'Get details based on callback id'
+    }
+  }
+]

--- a/src/bulkTransfers/handler.js
+++ b/src/bulkTransfers/handler.js
@@ -29,6 +29,7 @@ const callbacks = new NodeCache()
 const request = require('axios')
 const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
 
@@ -96,8 +97,8 @@ exports.postBulkTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -111,7 +112,7 @@ exports.postBulkTransfers = async function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(bulkTransferResponse)}]`)
       const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }
@@ -152,7 +153,7 @@ exports.postBulkTransfers = async function (req, h) {
     })
   }
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putBulkTransfersById = function (request, h) {
@@ -182,7 +183,7 @@ exports.putBulkTransfersById = function (request, h) {
     source: request.headers['fspiop-source'],
     destination: request.headers['fspiop-destination']
   })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putBulkTransfersByIdError = function (request, h) {
@@ -212,7 +213,7 @@ exports.putBulkTransfersByIdError = function (request, h) {
     source: request.headers['fspiop-source'],
     destination: request.headers['fspiop-destination']
   })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCorrelationId = function (request, h) {
@@ -228,7 +229,7 @@ exports.getCorrelationId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::getcorrelationId - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getBulkCorrelationId' })
-  return h.response(myCache.get(request.params.id)).code(202)
+  return h.response(myCache.get(request.params.id)).code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -244,7 +245,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getBulkRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -260,5 +261,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getBulkCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/bulkTransfers/handler.js
+++ b/src/bulkTransfers/handler.js
@@ -17,7 +17,7 @@
  optionally within square brackets <email>.
  * Gates Foundation
  - Rajiv Mothilal rajiv.mothilal@modusbox.com
-
+ - Steven Oderayi <steven.oderayi@modusbox.com>
  --------------
  ******/
 

--- a/src/health/handler.js
+++ b/src/health/handler.js
@@ -25,6 +25,8 @@
 
 'use strict'
 
+const Enums = require('@mojaloop/central-services-shared').Enum
+
 exports.health = function (request, h) {
-  return h.response({ status: 'OK' }).code(200)
+  return h.response({ status: 'OK' }).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/metrics/handler.js
+++ b/src/metrics/handler.js
@@ -25,7 +25,8 @@
 'use strict'
 
 const Metrics = require('../lib/metrics')
+const Enums = require('@mojaloop/central-services-shared').Enum
 
 exports.metrics = function (request, h) {
-  return h.response(Metrics.getMetricsForPrometheus()).code(200)
+  return h.response(Metrics.getMetricsForPrometheus()).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/noresponsepayeefsp/handler.js
+++ b/src/noresponsepayeefsp/handler.js
@@ -27,6 +27,7 @@ const myCache = new NodeCache()
 const requests = new NodeCache()
 const callbacks = new NodeCache()
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 
 const extractUrls = (request) => {
@@ -45,7 +46,7 @@ exports.metadata = function (request, h) {
   return h.response({
     directory: 'localhost',
     urls: extractUrls(request)
-  }).code(200)
+  }).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Transfers
@@ -72,7 +73,7 @@ exports.putTransfersById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putTransfersByIdError = function (request, h) {
@@ -96,7 +97,7 @@ exports.putTransfersByIdError = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersByIdError - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersByIdError', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -112,7 +113,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -128,5 +129,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/oracle/handler.js
+++ b/src/oracle/handler.js
@@ -28,6 +28,7 @@ const participantsCache = new NodeCache()
 const requestsCache = new NodeCache()
 const batchRequestCache = new NodeCache()
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 
 exports.createParticipantsByTypeAndId = function (request, h) {
@@ -86,7 +87,7 @@ exports.getParticipantsByTypeId = function (request, h) {
     response = []
   }
   histTimerEnd({ success: true, operation: 'getParticipants', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response(response).code(200)
+  return h.response(response).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.updateParticipantsByTypeId = function (request, h) {
@@ -120,7 +121,7 @@ exports.updateParticipantsByTypeId = function (request, h) {
     throw new Error(`Type:${request.params.Type} not found`)
   }
   histTimerEnd({ success: true, operation: 'putParticipants', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.delParticipantsByTypeId = function (request, h) {
@@ -229,7 +230,7 @@ exports.getRequestByTypeId = function (request, h) {
   const responseData = requestsCache.get(request.params.ID)
   requestsCache.del(request.params.ID)
   histTimerEnd({ success: true, operation: 'getRequestByTypeId' })
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -241,7 +242,7 @@ exports.getRequestById = function (request, h) {
   const responseData = batchRequestCache.get(request.params.requestId)
   batchRequestCache.del(request.params.requestId)
   histTimerEnd({ success: true, operation: 'getRequestById' })
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 const addNewRequest = function (request) {

--- a/src/payee/handler.js
+++ b/src/payee/handler.js
@@ -17,6 +17,7 @@
  optionally within square brackets <email>.
  * Gates Foundation
  - Murthy Kakarlamudi murthy@modusbox.com
+ - Steven Oderayi <steven.oderayi@modusbox.com>
  --------------
  ******/
 

--- a/src/payee/handler.js
+++ b/src/payee/handler.js
@@ -148,7 +148,6 @@ exports.getPartiesByTypeAndId = function (req, h) {
           traceparent: req.headers.traceparent ? req.headers.traceparent : '',
           tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
           return data

--- a/src/payee/handler.js
+++ b/src/payee/handler.js
@@ -29,6 +29,7 @@ const callbacks = new NodeCache()
 const request = require('axios')
 const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
 
@@ -57,7 +58,7 @@ exports.metadata = function (request, h) {
   return h.response({
     directory: 'localhost',
     urls: extractUrls(request)
-  }).code(200)
+  }).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /participants
@@ -83,7 +84,7 @@ exports.putParticipantsByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putParticipantsByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'putParticipantsByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.postPartiesByTypeAndId = function (request, h) {
@@ -100,7 +101,7 @@ exports.postPartiesByTypeAndId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::postPartiesByTypeAndId - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'postPartiesByTypeAndId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getPartiesByTypeAndId = function (req, h) {
@@ -145,8 +146,8 @@ exports.getPartiesByTypeAndId = function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/parties/${req.params.type}/${req.params.id}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -161,7 +162,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       Logger.info((new Date().toISOString()), 'Executing PUT', url)
       const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -175,7 +176,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
     }
   })()
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.postQuotes = function (req, h) {
@@ -259,8 +260,8 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -274,7 +275,7 @@ exports.postQuotes = function (req, h) {
       Logger.info((new Date().toISOString()), 'Executing PUT', url)
       const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -294,7 +295,7 @@ exports.postQuotes = function (req, h) {
       // rq.sendError(url, asyncResponses.serverError, rq.defaultHeaders(requesterName, 'participants'), {logger});
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.postTransfers = async function (req, h) {
@@ -348,8 +349,8 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -364,7 +365,7 @@ exports.postTransfers = async function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
       const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }
@@ -405,7 +406,7 @@ exports.postTransfers = async function (req, h) {
     })
   }
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putTransfersById = function (request, h) {
@@ -429,7 +430,7 @@ exports.putTransfersById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::putTransfersById - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'putTransfersById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putTransfersByIdError = function (request, h) {
@@ -453,7 +454,7 @@ exports.putTransfersByIdError = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::putTransfersByIdError - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'putTransfersByIdError', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getcorrelationId = function (request, h) {
@@ -469,7 +470,7 @@ exports.getcorrelationId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::getcorrelationId - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getcorrelationId' })
-  return h.response(myCache.get(request.params.id)).code(202)
+  return h.response(myCache.get(request.params.id)).code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -485,7 +486,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -501,5 +502,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payee', operation: 'getCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/payee/handler.js
+++ b/src/payee/handler.js
@@ -25,7 +25,8 @@ const NodeCache = require('node-cache')
 const myCache = new NodeCache()
 const requests = new NodeCache()
 const callbacks = new NodeCache()
-const fetch = require('node-fetch')
+const request = require('axios')
+const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
@@ -136,7 +137,6 @@ exports.getPartiesByTypeAndId = function (req, h) {
       const opts = {
         method: 'PUT',
         headers: {
-          Accept: 'application/vnd.interoperability.parties+json;version=1',
           'Content-Type': 'application/vnd.interoperability.parties+json;version=1.0',
           'FSPIOP-Source': 'payeefsp',
           'FSPIOP-Destination': req.headers['fspiop-source'],
@@ -144,16 +144,24 @@ exports.getPartiesByTypeAndId = function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/parties/${req.params.type}/${req.params.id}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
         rejectUnauthorized: false,
-        body: JSON.stringify(myCache.get(req.params.id))
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(myCache.get(req.params.id))
       }
+
       Logger.info((new Date().toISOString()), 'Executing PUT', url)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -251,16 +259,23 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(quotesResponse)
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(quotesResponse)
       }
       Logger.info((new Date().toISOString()), 'Executing PUT', url)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -334,16 +349,23 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(transfersResponse)
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(transfersResponse)
       }
+
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }

--- a/src/payee/handler.js
+++ b/src/payee/handler.js
@@ -264,7 +264,6 @@ exports.postQuotes = function (req, h) {
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
-
           return data
         }],
         httpsAgent: new https.Agent({

--- a/src/payer/handler.js
+++ b/src/payer/handler.js
@@ -29,6 +29,7 @@ const requests = new NodeCache()
 const callbacks = new NodeCache()
 const Metrics = require('../lib/metrics')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 
 const extractUrls = (request) => {
   const urls = {}
@@ -46,7 +47,7 @@ exports.metadata = function (request, h) {
   return h.response({
     directory: 'localhost',
     urls: extractUrls(request)
-  }).code(200)
+  }).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /participants
@@ -72,7 +73,7 @@ exports.putParticipantsByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putParticipantsByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putParticipantsByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /parties
@@ -98,7 +99,7 @@ exports.putPartiesByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putPartiesByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putPartiesByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putPartiesByTypeIdAndError = function (request, h) {
@@ -112,7 +113,7 @@ exports.putPartiesByTypeIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Quotes
@@ -138,7 +139,7 @@ exports.putQuotesById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putQuotesById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putQuotesById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putQuotesByIdAndError = function (request, h) {
@@ -152,7 +153,7 @@ exports.putQuotesByIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Transfers
@@ -178,7 +179,7 @@ exports.putTransfersById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putTransfersByIdError = function (request, h) {
@@ -202,7 +203,7 @@ exports.putTransfersByIdError = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersByIdError - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersByIdError', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getcorrelationId = function (request, h) {
@@ -218,7 +219,7 @@ exports.getcorrelationId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::getcorrelationId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getcorrelationId' })
-  return h.response(myCache.get(request.params.id)).code(202)
+  return h.response(myCache.get(request.params.id)).code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -234,7 +235,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -250,5 +251,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/shared/plugins.js
+++ b/src/shared/plugins.js
@@ -24,7 +24,7 @@
 
 const Package = require('../../package.json')
 const Inert = require('@hapi/inert')
-const Vision = require('vision')
+const Vision = require('@hapi/vision')
 const Blipp = require('blipp')
 const ErrorHandling = require('@mojaloop/central-services-error-handling')
 

--- a/src/testfsp1/handler.js
+++ b/src/testfsp1/handler.js
@@ -26,7 +26,8 @@ const NodeCache = require('node-cache')
 const myCache = new NodeCache()
 const requests = new NodeCache()
 const callbacks = new NodeCache()
-const fetch = require('node-fetch')
+const request = require('axios')
+const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
@@ -112,21 +113,26 @@ exports.getPartiesByTypeAndId = function (req, h) {
       const opts = {
         method: 'PUT',
         headers: {
-          Accept: 'application/vnd.interoperability.parties+json;version=1',
           'Content-Type': 'application/vnd.interoperability.parties+json;version=1.0',
           'FSPIOP-Source': 'testfsp1',
           'FSPIOP-Destination': req.headers['fspiop-source'],
           Date: req.headers.date,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(myCache.get(req.params.id))
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(myCache.get(req.params.id))
       }
       console.log((new Date().toISOString()), 'Executing PUT', url)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       console.log((new Date().toISOString()), 'response: ', res.status)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error('Failed to send. Result:', res)
       }
@@ -258,16 +264,22 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(quotesResponse)
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(quotesResponse)
       }
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(quotesResponse)}]`)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -381,16 +393,15 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(transfersResponse)
+        data: JSON.stringify(transfersResponse)
       }
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }

--- a/src/testfsp1/handler.js
+++ b/src/testfsp1/handler.js
@@ -30,6 +30,7 @@ const callbacks = new NodeCache()
 const request = require('axios')
 const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
 
@@ -58,7 +59,7 @@ exports.metadata = function (request, h) {
   return h.response({
     directory: 'localhost',
     urls: extractUrls(request)
-  }).code(200)
+  }).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /participants
@@ -84,7 +85,7 @@ exports.putParticipantsByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putParticipantsByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putParticipantsByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /parties
@@ -102,7 +103,7 @@ exports.postPartiesByTypeAndId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::postPartiesByTypeAndId - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'postPartiesByTypeAndId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getPartiesByTypeAndId = function (req, h) {
@@ -118,8 +119,8 @@ exports.getPartiesByTypeAndId = function (req, h) {
           'FSPIOP-Source': 'testfsp1',
           'FSPIOP-Destination': req.headers['fspiop-source'],
           Date: req.headers.date,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -133,7 +134,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       console.log((new Date().toISOString()), 'Executing PUT', url)
       const res = await request(url, opts)
       console.log((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error('Failed to send. Result:', res)
       }
@@ -141,7 +142,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       console.log(['error'], err)
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putPartiesByTypeId = function (request, h) {
@@ -166,7 +167,7 @@ exports.putPartiesByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putPartiesByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putPartiesByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putPartiesByTypeIdAndError = function (request, h) {
@@ -180,7 +181,7 @@ exports.putPartiesByTypeIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Quotes
@@ -265,8 +266,8 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -280,7 +281,7 @@ exports.postQuotes = function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(quotesResponse)}]`)
       const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -300,7 +301,7 @@ exports.postQuotes = function (req, h) {
       // rq.sendError(url, asyncResponses.serverError, rq.defaultHeaders(requesterName, 'participants'), {logger});
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putQuotesById = function (request, h) {
@@ -325,7 +326,7 @@ exports.putQuotesById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putQuotesById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putQuotesById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putQuotesByIdAndError = function (request, h) {
@@ -339,7 +340,7 @@ exports.putQuotesByIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Transfers
@@ -394,15 +395,15 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         data: JSON.stringify(transfersResponse)
       }
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
       const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }
@@ -443,7 +444,7 @@ exports.postTransfers = async function (req, h) {
     })
   }
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putTransfersById = function (request, h) {
@@ -468,7 +469,7 @@ exports.putTransfersById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putTransfersByIdError = function (request, h) {
@@ -492,7 +493,7 @@ exports.putTransfersByIdError = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersByIdError - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersByIdError', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getcorrelationId = function (request, h) {
@@ -508,7 +509,7 @@ exports.getcorrelationId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::getcorrelationId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getcorrelationId' })
-  return h.response(myCache.get(request.params.id)).code(202)
+  return h.response(myCache.get(request.params.id)).code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -524,7 +525,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -540,5 +541,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/testfsp2/handler.js
+++ b/src/testfsp2/handler.js
@@ -30,6 +30,7 @@ const callbacks = new NodeCache()
 const request = require('axios')
 const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
 
@@ -58,7 +59,7 @@ exports.metadata = function (request, h) {
   return h.response({
     directory: 'localhost',
     urls: extractUrls(request)
-  }).code(200)
+  }).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /participants
@@ -84,7 +85,7 @@ exports.putParticipantsByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putParticipantsByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putParticipantsByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /parties
@@ -102,7 +103,7 @@ exports.postPartiesByTypeAndId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::postPartiesByTypeAndId - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'postPartiesByTypeAndId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getPartiesByTypeAndId = function (req, h) {
@@ -118,8 +119,8 @@ exports.getPartiesByTypeAndId = function (req, h) {
           'FSPIOP-Source': 'testfsp2',
           'FSPIOP-Destination': req.headers['fspiop-source'],
           Date: req.headers.date,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -133,7 +134,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       console.log((new Date().toISOString()), 'Executing PUT', url)
       const res = await request(url, opts)
       console.log((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error('Failed to send. Result:', res)
       }
@@ -141,7 +142,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       console.log(['error'], err)
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putPartiesByTypeId = function (request, h) {
@@ -166,7 +167,7 @@ exports.putPartiesByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putPartiesByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putPartiesByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putPartiesByTypeIdAndError = function (request, h) {
@@ -180,7 +181,7 @@ exports.putPartiesByTypeIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Quotes
@@ -265,8 +266,8 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -280,7 +281,7 @@ exports.postQuotes = function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(quotesResponse)}]`)
       const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -300,7 +301,7 @@ exports.postQuotes = function (req, h) {
       // rq.sendError(url, asyncResponses.serverError, rq.defaultHeaders(requesterName, 'participants'), {logger});
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putQuotesById = function (request, h) {
@@ -325,7 +326,7 @@ exports.putQuotesById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putQuotesById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putQuotesById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putQuotesByIdAndError = function (request, h) {
@@ -339,7 +340,7 @@ exports.putQuotesByIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Transfers
@@ -394,8 +395,8 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -409,7 +410,7 @@ exports.postTransfers = async function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
       const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }
@@ -450,7 +451,7 @@ exports.postTransfers = async function (req, h) {
     })
   }
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putTransfersById = function (request, h) {
@@ -475,7 +476,7 @@ exports.putTransfersById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putTransfersByIdError = function (request, h) {
@@ -499,7 +500,7 @@ exports.putTransfersByIdError = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersByIdError - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersByIdError', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getcorrelationId = function (request, h) {
@@ -515,7 +516,7 @@ exports.getcorrelationId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::getcorrelationId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getcorrelationId' })
-  return h.response(myCache.get(request.params.id)).code(202)
+  return h.response(myCache.get(request.params.id)).code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -531,7 +532,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -547,5 +548,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/testfsp2/handler.js
+++ b/src/testfsp2/handler.js
@@ -17,6 +17,7 @@
  optionally within square brackets <email>.
  * Gates Foundation
  - Sridevi Miriyala sridevi.miriyala@modusbox.com
+ - Steven Oderayi <steven.oderayi@modusbox.com>
  --------------
  ******/
 

--- a/src/testfsp3/handler.js
+++ b/src/testfsp3/handler.js
@@ -30,6 +30,7 @@ const callbacks = new NodeCache()
 const request = require('axios')
 const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
 
@@ -58,7 +59,7 @@ exports.metadata = function (request, h) {
   return h.response({
     directory: 'localhost',
     urls: extractUrls(request)
-  }).code(200)
+  }).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /participants
@@ -84,7 +85,7 @@ exports.putParticipantsByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putParticipantsByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putParticipantsByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /parties
@@ -102,7 +103,7 @@ exports.postPartiesByTypeAndId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::postPartiesByTypeAndId - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'postPartiesByTypeAndId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getPartiesByTypeAndId = function (req, h) {
@@ -118,8 +119,8 @@ exports.getPartiesByTypeAndId = function (req, h) {
           'FSPIOP-Source': 'testfsp3',
           'FSPIOP-Destination': req.headers['fspiop-source'],
           Date: req.headers.date,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -133,7 +134,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       console.log((new Date().toISOString()), 'Executing PUT', url)
       const res = await request(url, opts)
       console.log((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error('Failed to send. Result:', res)
       }
@@ -141,7 +142,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       console.log(['error'], err)
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putPartiesByTypeId = function (request, h) {
@@ -166,7 +167,7 @@ exports.putPartiesByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putPartiesByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putPartiesByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putPartiesByTypeIdAndError = function (request, h) {
@@ -180,7 +181,7 @@ exports.putPartiesByTypeIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Quotes
@@ -265,8 +266,8 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -280,7 +281,7 @@ exports.postQuotes = function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(quotesResponse)}]`)
       const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -300,7 +301,7 @@ exports.postQuotes = function (req, h) {
       // rq.sendError(url, asyncResponses.serverError, rq.defaultHeaders(requesterName, 'participants'), {logger});
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putQuotesById = function (request, h) {
@@ -325,7 +326,7 @@ exports.putQuotesById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putQuotesById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putQuotesById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putQuotesByIdAndError = function (request, h) {
@@ -339,7 +340,7 @@ exports.putQuotesByIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Transfers
@@ -394,8 +395,8 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -409,7 +410,7 @@ exports.postTransfers = async function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
       const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }
@@ -450,7 +451,7 @@ exports.postTransfers = async function (req, h) {
     })
   }
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putTransfersById = function (request, h) {
@@ -475,7 +476,7 @@ exports.putTransfersById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putTransfersByIdError = function (request, h) {
@@ -499,7 +500,7 @@ exports.putTransfersByIdError = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersByIdError - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersByIdError', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getcorrelationId = function (request, h) {
@@ -515,7 +516,7 @@ exports.getcorrelationId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::getcorrelationId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getcorrelationId' })
-  return h.response(myCache.get(request.params.id)).code(202)
+  return h.response(myCache.get(request.params.id)).code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -531,7 +532,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -547,5 +548,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/testfsp3/handler.js
+++ b/src/testfsp3/handler.js
@@ -26,7 +26,8 @@ const NodeCache = require('node-cache')
 const myCache = new NodeCache()
 const requests = new NodeCache()
 const callbacks = new NodeCache()
-const fetch = require('node-fetch')
+const request = require('axios')
+const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
@@ -112,21 +113,26 @@ exports.getPartiesByTypeAndId = function (req, h) {
       const opts = {
         method: 'PUT',
         headers: {
-          Accept: 'application/vnd.interoperability.parties+json;version=1',
           'Content-Type': 'application/vnd.interoperability.parties+json;version=1.0',
           'FSPIOP-Source': 'testfsp3',
           'FSPIOP-Destination': req.headers['fspiop-source'],
           Date: req.headers.date,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(myCache.get(req.params.id))
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(myCache.get(req.params.id))
       }
       console.log((new Date().toISOString()), 'Executing PUT', url)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       console.log((new Date().toISOString()), 'response: ', res.status)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error('Failed to send. Result:', res)
       }
@@ -258,16 +264,22 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(quotesResponse)
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(quotesResponse)
       }
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(quotesResponse)}]`)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -381,16 +393,22 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(transfersResponse)
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(transfersResponse)
       }
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }

--- a/src/testfsp3/handler.js
+++ b/src/testfsp3/handler.js
@@ -17,6 +17,7 @@
  optionally within square brackets <email>.
  * Gates Foundation
  - Sridevi Miriyala sridevi.miriyala@modusbox.com
+ - Steven Oderayi <steven.oderayi@modusbox.com>
  --------------
  ******/
 

--- a/src/testfsp4/handler.js
+++ b/src/testfsp4/handler.js
@@ -30,6 +30,7 @@ const callbacks = new NodeCache()
 const request = require('axios')
 const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
 
@@ -58,7 +59,7 @@ exports.metadata = function (request, h) {
   return h.response({
     directory: 'localhost',
     urls: extractUrls(request)
-  }).code(200)
+  }).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /participants
@@ -84,7 +85,7 @@ exports.putParticipantsByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putParticipantsByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putParticipantsByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about /parties
@@ -102,7 +103,7 @@ exports.postPartiesByTypeAndId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payee::postPartiesByTypeAndId - END`)
   histTimerEnd({ success: true, fsp: 'payee', operation: 'postPartiesByTypeAndId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getPartiesByTypeAndId = function (req, h) {
@@ -118,8 +119,8 @@ exports.getPartiesByTypeAndId = function (req, h) {
           'FSPIOP-Source': 'testfsp4',
           'FSPIOP-Destination': req.headers['fspiop-source'],
           Date: req.headers.date,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -133,7 +134,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       console.log((new Date().toISOString()), 'Executing PUT', url)
       const res = await request(url, opts)
       console.log((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error('Failed to send. Result:', res)
       }
@@ -141,7 +142,7 @@ exports.getPartiesByTypeAndId = function (req, h) {
       console.log(['error'], err)
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putPartiesByTypeId = function (request, h) {
@@ -166,7 +167,7 @@ exports.putPartiesByTypeId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putPartiesByTypeId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putPartiesByTypeId', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putPartiesByTypeIdAndError = function (request, h) {
@@ -180,7 +181,7 @@ exports.putPartiesByTypeIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Quotes
@@ -265,8 +266,8 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -280,7 +281,7 @@ exports.postQuotes = function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(quotesResponse)}]`)
       const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -300,7 +301,7 @@ exports.postQuotes = function (req, h) {
       // rq.sendError(url, asyncResponses.serverError, rq.defaultHeaders(requesterName, 'participants'), {logger});
     }
   })()
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putQuotesById = function (request, h) {
@@ -325,7 +326,7 @@ exports.putQuotesById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putQuotesById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putQuotesById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putQuotesByIdAndError = function (request, h) {
@@ -339,7 +340,7 @@ exports.putQuotesByIdAndError = function (request, h) {
   }
   callbacks.set(request.params.id, incomingRequest)
 
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 // Section about Transfers
@@ -394,8 +395,8 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
-          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
+          traceparent: req.headers.traceparent || '',
+          tracestate: req.headers.tracestate || ''
         },
         transformRequest: [(data, headers) => {
           delete headers.common.Accept
@@ -409,7 +410,7 @@ exports.postTransfers = async function (req, h) {
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
       const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (res.status !== 202) {
+      if (res.status !== Enums.Http.ReturnCodes.ACCEPTED.CODE) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }
@@ -450,7 +451,7 @@ exports.postTransfers = async function (req, h) {
     })
   }
 
-  return h.response().code(202)
+  return h.response().code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.putTransfersById = function (request, h) {
@@ -475,7 +476,7 @@ exports.putTransfersById = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersById - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersById', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.putTransfersByIdError = function (request, h) {
@@ -499,7 +500,7 @@ exports.putTransfersByIdError = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::putTransfersByIdError - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'putTransfersByIdError', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getcorrelationId = function (request, h) {
@@ -515,7 +516,7 @@ exports.getcorrelationId = function (request, h) {
 
   // Logger.perf(`[cid=${request.payload.transferId}, fsp=${request.headers['fspiop-source']}, source=${request.headers['fspiop-source']}, dest=${request.headers['fspiop-destination']}] ~ Simulator::api::payer::getcorrelationId - END`)
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getcorrelationId' })
-  return h.response(myCache.get(request.params.id)).code(202)
+  return h.response(myCache.get(request.params.id)).code(Enums.Http.ReturnCodes.ACCEPTED.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -531,7 +532,7 @@ exports.getRequestById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getRequestById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getCallbackById = function (request, h) {
@@ -547,5 +548,5 @@ exports.getCallbackById = function (request, h) {
 
   histTimerEnd({ success: true, fsp: 'payer', operation: 'getCallbackById' })
 
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }

--- a/src/testfsp4/handler.js
+++ b/src/testfsp4/handler.js
@@ -26,7 +26,8 @@ const NodeCache = require('node-cache')
 const myCache = new NodeCache()
 const requests = new NodeCache()
 const callbacks = new NodeCache()
-const fetch = require('node-fetch')
+const request = require('axios')
+const https = require('https')
 const Logger = require('@mojaloop/central-services-shared').Logger
 const Metrics = require('../lib/metrics')
 const base64url = require('base64url')
@@ -112,21 +113,26 @@ exports.getPartiesByTypeAndId = function (req, h) {
       const opts = {
         method: 'PUT',
         headers: {
-          Accept: 'application/vnd.interoperability.parties+json;version=1',
           'Content-Type': 'application/vnd.interoperability.parties+json;version=1.0',
           'FSPIOP-Source': 'testfsp4',
           'FSPIOP-Destination': req.headers['fspiop-source'],
           Date: req.headers.date,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(myCache.get(req.params.id))
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(myCache.get(req.params.id))
       }
       console.log((new Date().toISOString()), 'Executing PUT', url)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       console.log((new Date().toISOString()), 'response: ', res.status)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error('Failed to send. Result:', res)
       }
@@ -258,16 +264,22 @@ exports.postQuotes = function (req, h) {
           'FSPIOP-Signature': `${JSON.stringify(fspiopSignature)}`,
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': `/quotes/${quotesRequest.quoteId}`,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(quotesResponse)
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(quotesResponse)
       }
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(quotesResponse)}]`)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info((new Date().toISOString()), 'response: ', res.status)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${res}`)
       }
@@ -381,16 +393,22 @@ exports.postTransfers = async function (req, h) {
           'FSPIOP-Signature': JSON.stringify(fspiopSignature),
           'FSPIOP-HTTP-Method': 'PUT',
           'FSPIOP-URI': fspiopUriHeader,
-          traceparent: req.headers.traceparent ? req.headers.traceparent : undefined,
-          tracestate: req.headers.tracestate ? req.headers.tracestate : undefined
+          traceparent: req.headers.traceparent ? req.headers.traceparent : '',
+          tracestate: req.headers.tracestate ? req.headers.tracestate : ''
         },
-        rejectUnauthorized: false,
-        body: JSON.stringify(transfersResponse)
+        transformRequest: [(data, headers) => {
+          delete headers.common.Accept
+          return data
+        }],
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false
+        }),
+        data: JSON.stringify(transfersResponse)
       }
       Logger.info(`Executing PUT: [${url}], HEADERS: [${JSON.stringify(opts.headers)}], BODY: [${JSON.stringify(transfersResponse)}]`)
-      const res = await fetch(url, opts)
+      const res = await request(url, opts)
       Logger.info(`response: ${res.status}`)
-      if (!res.ok) {
+      if (res.status !== 202) {
         // TODO: how does one identify the failed response?
         throw new Error(`Failed to send. Result: ${JSON.stringify(res)}`)
       }

--- a/src/testfsp4/handler.js
+++ b/src/testfsp4/handler.js
@@ -17,6 +17,7 @@
  optionally within square brackets <email>.
  * Gates Foundation
  - Sridevi Miriyala sridevi.miriyala@modusbox.com
+ - Steven Oderayi <steven.oderayi@modusbox.com>
  --------------
  ******/
 

--- a/src/transactionRequests/handler.js
+++ b/src/transactionRequests/handler.js
@@ -28,6 +28,7 @@ const participantsCache = new NodeCache()
 const requestsCache = new NodeCache()
 const batchRequestCache = new NodeCache()
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Enums = require('@mojaloop/central-services-shared').Enum
 const Metrics = require('../lib/metrics')
 
 exports.createParticipantsByTypeAndId = function (request, h) {
@@ -86,7 +87,7 @@ exports.getParticipantsByTypeId = function (request, h) {
     response = []
   }
   histTimerEnd({ success: true, operation: 'getParticipants', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response(response).code(200)
+  return h.response(response).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.updateParticipantsByTypeId = function (request, h) {
@@ -120,7 +121,7 @@ exports.updateParticipantsByTypeId = function (request, h) {
     throw new Error(`Type:${request.params.Type} not found`)
   }
   histTimerEnd({ success: true, operation: 'putParticipants', source: request.headers['fspiop-source'], destination: request.headers['fspiop-destination'] })
-  return h.response().code(200)
+  return h.response().code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.delParticipantsByTypeId = function (request, h) {
@@ -229,7 +230,7 @@ exports.getRequestByTypeId = function (request, h) {
   const responseData = requestsCache.get(request.params.ID)
   requestsCache.del(request.params.ID)
   histTimerEnd({ success: true, operation: 'getRequestByTypeId' })
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 exports.getRequestById = function (request, h) {
@@ -241,7 +242,7 @@ exports.getRequestById = function (request, h) {
   const responseData = batchRequestCache.get(request.params.requestId)
   batchRequestCache.del(request.params.requestId)
   histTimerEnd({ success: true, operation: 'getRequestById' })
-  return h.response(responseData).code(200)
+  return h.response(responseData).code(Enums.Http.ReturnCodes.OK.CODE)
 }
 
 const addNewRequest = function (request) {


### PR DESCRIPTION
Related issue [#935](https://github.com/mojaloop/project/issues/935)

This PR ensures that no 'Accept' header is sent in `PUT` requests, in compliance with the Mojaloop specification.
To achieve this:
- `node-fetch` had to be replaced with `axios` because there are no ways to prevent `node-fetch` from send the `Accept` header.
- `acceptheaderpayeefsp` was added to simulate a FSP that sends the unwanted `Accept` header, for 'negative' testing. Any request to this FSP that requires a 'PUT' callback should fail.
 